### PR TITLE
Fix/latest webdriver

### DIFF
--- a/appium-dotnet-driver/Appium/AppiumDriver.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriver.cs
@@ -164,11 +164,24 @@ namespace OpenQA.Selenium.Appium
 
         #region Public Methods
 
-        protected override Response Execute(string driverCommandToExecute, Dictionary<string, object> parameters) =>
-            base.Execute(driverCommandToExecute, parameters);
+        protected override Response Execute(string driverCommandToExecute, Dictionary<string, object> parameters)
+        {
+            // once the "capabilities" is attached in parameters, the appium driver will return the data without "status" field (such as status:0)
+            // remove "capabilities" so that the appium will return the json data with "status" field.
+            // if the returned json data has no "status" field, the web driver will be treated as Specification Compliant
+            // and all the methods of WebElement will go to the if branch (actually it should go to the else branch)
+            // see RemoteWebElement.Displayed for example.
+            string key = "capabilities";
+            if (parameters != null && parameters.ContainsKey(key))
+            {
+                parameters.Remove(key);
+            }
+
+            return base.Execute(driverCommandToExecute, parameters);
+        }
 
         Response IExecuteMethod.Execute(string commandName, Dictionary<string, object> parameters) =>
-            base.Execute(commandName, parameters);
+            this.Execute(commandName, parameters);
 
         Response IExecuteMethod.Execute(string driverCommand) => Execute(driverCommand, null);
 

--- a/appium-dotnet-driver/Appium/Extensions/DesiredCapabilitiesExtensions.cs
+++ b/appium-dotnet-driver/Appium/Extensions/DesiredCapabilitiesExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using OpenQA.Selenium.Remote;
+
+namespace OpenQA.Selenium.Appium.Extensions
+{
+    public static class DesiredCapabilitiesExtensions
+    {
+        public static Dictionary<string, object> ToDictionary(this DesiredCapabilities desiredCapabilities)
+        {
+            Type type = typeof(DesiredCapabilities);
+            Type hasCapabilities = type.GetInterface("IHasCapabilitiesDictionary");
+            PropertyInfo property = hasCapabilities.GetProperty("CapabilitiesDictionary");
+            MethodInfo method = property.GetGetMethod();
+            Dictionary<string, object> dictionary = method.Invoke(desiredCapabilities, new object[0]) as Dictionary<string, object>;
+            return dictionary;
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/Service/Options/OptionCollector.cs
+++ b/appium-dotnet-driver/Appium/Service/Options/OptionCollector.cs
@@ -15,6 +15,7 @@
 using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
+using OpenQA.Selenium.Appium.Extensions;
 
 namespace OpenQA.Selenium.Appium.Service.Options
 {

--- a/appium-dotnet-driver/appium-dotnet-driver.csproj
+++ b/appium-dotnet-driver/appium-dotnet-driver.csproj
@@ -53,11 +53,11 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver, Version=3.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.3.13.0\lib\net45\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.14.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.14.0\lib\net45\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=3.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.Support.3.13.0\lib\net45\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.14.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.14.0\lib\net45\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -83,6 +83,7 @@
     <Compile Include="Appium\Enums\MobileCapabilityType.cs" />
     <Compile Include="Appium\Android\Enums\ConnectionType.cs" />
     <Compile Include="Appium\Enums\MobileSelector.cs" />
+    <Compile Include="Appium\Extensions\DesiredCapabilitiesExtensions.cs" />
     <Compile Include="Appium\Interfaces\IFindsByIosNSPredicate.cs" />
     <Compile Include="Appium\Interfaces\IExecuteMethod.cs" />
     <Compile Include="Appium\Interfaces\IFindsByFluentSelector.cs" />

--- a/appium-dotnet-driver/packages.config
+++ b/appium-dotnet-driver/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.NetCore.Analyzers" version="2.6.2-beta2" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.6.2-beta2" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-  <package id="Selenium.Support" version="3.13.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="3.13.0" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.14.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.14.0" targetFramework="net45" />
   <package id="Text.Analyzers" version="2.6.2-beta2" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/integration_tests/Extensions/DesiredCapabilitiesExtensionsTest.cs
+++ b/integration_tests/Extensions/DesiredCapabilitiesExtensionsTest.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Appium.Integration.Tests.Helpers;
+using NUnit.Framework;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Appium.Extensions;
+using OpenQA.Selenium.Appium.Enums;
+
+namespace Appium.Integration.Tests.Extensions
+{
+    [TestFixture]
+    public class DesiredCapabilitiesExtensionsTest
+    {
+        [Test]
+        public void ToDictionaryTest()
+        {
+            DesiredCapabilities capabilities = new DesiredCapabilities();
+            capabilities.SetCapability(MobileCapabilityType.PlatformName, MobilePlatform.Android);
+            capabilities.SetCapability(AndroidMobileCapabilityType.AppActivity, ".SplashActivity");
+            capabilities.SetCapability(MobileCapabilityType.PlatformVersion, "8.1");
+            capabilities.SetCapability(MobileCapabilityType.DeviceName, "Nexus_6_API_27");
+            capabilities.SetCapability(MobileCapabilityType.NewCommandTimeout, 600);
+            capabilities.SetCapability(MobileCapabilityType.NoReset, false);
+            capabilities.SetCapability(MobileCapabilityType.FullReset, true);
+            capabilities.SetCapability(MobileCapabilityType.AutomationName, AutomationName.AndroidUIAutomator2);
+            capabilities.SetCapability("autoGrantPermissions", true);
+            Dictionary<string, object> dic = capabilities.ToDictionary();
+            Assert.AreEqual(9, dic.Count);
+            Assert.AreEqual(MobilePlatform.Android, dic[MobileCapabilityType.PlatformName]);
+            Assert.AreEqual(".SplashActivity", dic[AndroidMobileCapabilityType.AppActivity]);
+            Assert.AreEqual("8.1", dic[MobileCapabilityType.PlatformVersion]);
+            Assert.AreEqual("Nexus_6_API_27", dic[MobileCapabilityType.DeviceName]);
+            Assert.AreEqual(600, dic[MobileCapabilityType.NewCommandTimeout]);
+            Assert.AreEqual(false, dic[MobileCapabilityType.NoReset]);
+            Assert.AreEqual(true, dic[MobileCapabilityType.FullReset]);
+            Assert.AreEqual(AutomationName.AndroidUIAutomator2, dic[MobileCapabilityType.AutomationName]);
+            Assert.AreEqual(true, dic["autoGrantPermissions"]);
+        }
+    }
+}

--- a/integration_tests/integration_tests.csproj
+++ b/integration_tests/integration_tests.csproj
@@ -52,11 +52,11 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="WebDriver, Version=3.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.3.13.0\lib\net45\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.14.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.14.0\lib\net45\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=3.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.Support.3.13.0\lib\net45\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.14.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.14.0\lib\net45\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -74,6 +74,7 @@
     <Compile Include="Android\AndroidOrientationTest.cs" />
     <Compile Include="Android\IntentAndroidTest.cs" />
     <Compile Include="Android\SessionDetailTest.cs" />
+    <Compile Include="Extensions\DesiredCapabilitiesExtensionsTest.cs" />
     <Compile Include="helpers\Apps.cs" />
     <Compile Include="helpers\Caps.cs" />
     <Compile Include="helpers\AppiumServers.cs" />

--- a/integration_tests/packages.config
+++ b/integration_tests/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.NetCore.Analyzers" version="2.6.2-beta2" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="2.6.2-beta2" targetFramework="net45" developmentDependency="true" />
   <package id="NUnit" version="3.10.1" targetFramework="net45" />
-  <package id="Selenium.Support" version="3.13.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="3.13.0" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.14.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.14.0" targetFramework="net45" />
   <package id="Text.Analyzers" version="2.6.2-beta2" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
## Change list

make appium-dotnet-driver work with latest selenium webdriver (3.14.0)
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

**The appium-driver now create session with parameter like below (not work well):**
{"desiredCapabilities":{"platformName":"iOS","platformVersion":"11.4","deviceName":"iPhone X","newCommandTimeout":600,"noReset":false,"fullReset":false,"automationName":"XCuiTest","waitForQuiescence":false,"platform":"MAC"},**"capabilities":{"firstMatch":[{"platformName":"iOS"}]}**}
**and with response like:**
{"value":{"capabilities":{"webStorageEnabled":false,"locationContextEnabled":false,"browserName":"","platform":"MAC","javascriptEnabled":true,"databaseEnabled":false,"takesScreenshot":true,"networkConnectionEnabled":false,"platformName":"iOS","platformVersion":"11.4","deviceName":"iPhone X","newCommandTimeout":600,"noReset":false,"fullReset":false,"automationName":"XCuiTest","waitForQuiescence":false,"udid":"054E081D-2F11-45E1-B27E-5E5EAC98FEF4"},"sessionId":"4a2a12d2-95f8-4697-8976-7219c0dd7e1d"}}

**But in an older version it creates session with (works well):**
{"desiredCapabilities":{"platformName":"iOS","platformVersion":"11.4","deviceName":"iPhone X","newCommandTimeout":600,"noReset":false,"fullReset":false,"automationName":"XCuiTest","waitForQuiescence":false,"platform":"MAC"}}
**and with response like:**
{**"status":0,"value"**:{"webStorageEnabled":false,"locationContextEnabled":false,"browserName":"","platform":"MAC","javascriptEnabled":true,"databaseEnabled":false,"takesScreenshot":true,"networkConnectionEnabled":false,"platformName":"iOS","platformVersion":"11.4","deviceName":"iPhone X","newCommandTimeout":600,"noReset":false,"fullReset":false,"automationName":"XCuiTest","waitForQuiescence":false,"udid":"054E081D-2F11-45E1-B27E-5E5EAC98FEF4"},"sessionId":"ec52f26b-a581-448c-9c58-85a57cd26a75"}

The differences are now it sends an additional **"capabilities":{"firstMatch":[{"platformName":"iOS"}]}** while older one not. So the response now has no **"status":0** field. That is the problem which appium driver will be treated as SpecificationCompliant=true. And all the methods in RemoteWebElement in appium will go to the if branch which is fit for browser, not appium.
For example the Displayed property:
`public virtual bool Displayed
        {
            get
            {
                Response commandResponse = null;
                Dictionary<string, object> parameters = new Dictionary<string, object>();
                if (this.driver.IsSpecificationCompliant)
                {
                    string atom = GetAtom("isDisplayed.js");
                    parameters.Add("script", atom);
                    parameters.Add("args", new object[] { this.ToElementReference().ToDictionary() });
                    commandResponse = this.Execute(DriverCommand.ExecuteScript, parameters);
                }
                else
                {
                    parameters.Add("id", this.Id);
                    commandResponse = this.Execute(DriverCommand.IsElementDisplayed, parameters);
                }

                return (bool)commandResponse.Value;
            }
        }`
currently we use a workaround to make the AppiumDriver's Execute method remove the request data "capablities".